### PR TITLE
Update: schema links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It adds the `init`, `deps`, `dev` and `build` commands to the `Command Palette`.
 
 ## JSON validation
 
-The extension automatically pulls the [latest config schema](https://github.com/tauri-apps/tauri/blob/dev/tooling/cli.rs/schema.json) so VS Code can display documentation and autocomplete.
+The extension automatically pulls the [latest config schema](https://github.com/tauri-apps/tauri/blob/dev/tooling/cli/schema.json) so VS Code can display documentation and autocomplete.
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
           "tauri.conf.json",
           "tauri.*.conf.json"
         ],
-        "url": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/tooling/cli.rs/schema.json"
+        "url": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/tooling/cli/schema.json"
       }
     ],
     "commands": [


### PR DESCRIPTION
updated the schema links to point: `/tooling/cli/schema.json` instead of `/tooling/cli.rs/schema.json`

For Ref: https://github.com/tauri-apps/tauri/pull/3388