### PR TITLE
fix: use stripAnsi to remove ansi colors in output

### DIFF
--- a/.changes/strip-ansi.md
+++ b/.changes/strip-ansi.md
@@ -1,0 +1,5 @@
+---
+'tauri-vscode': patch
+---
+
+use stripAnsi to remove ansi colors in output

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     "@types/semver": "^7.3.12",
     "axios": "^0.27.2",
     "glob": "8.0.3",
-    "run-in-terminal": "^0.0.3"
+    "run-in-terminal": "^0.0.3",
+    "strip-ansi": "^6.0.1"
   },
   "resolutions": {
     "brace-expansion": "^2.0.1"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,9 @@ import { runInTerminal } from 'run-in-terminal';
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import axios from 'axios';
+
+import stripAnsi = require('strip-ansi');
+
 const glob = require('glob');
 const path = require('path');
 const fs = require('fs');
@@ -340,10 +343,10 @@ function __runCommandInOutputWindow(
     runningProcesses.set(p.pid, { process: p, cmd: cmd });
 
     p.stderr?.on('data', (data: string) => {
-      outputChannel.append(data);
+      outputChannel.append(stripAnsi(data));
     });
     p.stdout?.on('data', (data: string) => {
-      outputChannel.append(data);
+      outputChannel.append(stripAnsi(data));
     });
     p.on('exit', (_code: number, signal: string) => {
       runningProcesses.delete(p.pid!);


### PR DESCRIPTION
remove ansi colors in output, make output more clean and readable

fix [issues/172](https://github.com/tauri-apps/tauri-vscode/issues/172)

![image](https://user-images.githubusercontent.com/2155893/216852417-fb308c17-027b-4844-9000-d8db16a76ce1.png)
