### PR TITLE
fix: Fix Init command

### DIFF
--- a/.changes/fix-init.md
+++ b/.changes/fix-init.md
@@ -1,0 +1,6 @@
+---
+'tauri-vscode': patch
+---
+
+Fix `Tauri: Init` command. That command tried to detect workspaces with a `src-tauri` directory, which does not exist yet when `Init` is used.
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,7 +199,7 @@ function runTauriInit(): void {
     () => {
       const paths = __getNpmProjectsPaths()
       return paths.filter((p) => {
-        return fs.existsSync(path.join(p, 'src-tauri'))
+        return !fs.existsSync(path.join(p, 'src-tauri'))
       })
     }
   )


### PR DESCRIPTION
On a workspace without Tauri (e.g. a workspace generated with `pnpm create vite .`), the `Tauri: Init` command fails with error message `Tauri project not found`.

That's because of a regression in #242:
https://github.com/tauri-apps/tauri-vscode/pull/242/files#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L199

The Init command should search a directory with NO subdirectory named `src-tauri`, because Tauri is not installed yet.
